### PR TITLE
optimized Docker image and added a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-server/helm/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+server/helm/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,10 +1,20 @@
-FROM golang:latest
+### builder stage ###
 
-WORKDIR .
+FROM golang:latest as builder
+
+WORKDIR /app
 
 COPY . .
 
-RUN go build -o server .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server .
+
+### image stage ###
+
+FROM alpine
+
+WORKDIR /root/
+
+COPY --from=builder /app/server .
 
 EXPOSE 9999
 


### PR DESCRIPTION
optimized the Docker image size (from 810MB to 13MB)

added a `.gitignore` to avoid committing deployment files